### PR TITLE
Handle missing env var failures in actions fetch script

### DIFF
--- a/scripts/fetch-actions-status.js
+++ b/scripts/fetch-actions-status.js
@@ -1,11 +1,25 @@
 import { writeFile } from "fs/promises";
 
+const OUTPUT_PATH = "public/data/actions.json";
+
+async function writeRuns(runs) {
+  await writeFile(OUTPUT_PATH, JSON.stringify(runs, null, 2));
+}
+
+async function writeFallback(reason) {
+  console.warn(
+    `[actions-status] ${reason}. Writing empty workflow run list to ${OUTPUT_PATH}.`,
+  );
+  await writeRuns([]);
+}
+
 async function main() {
   const repo = process.env.GITHUB_REPOSITORY;
   const token = process.env.GITHUB_TOKEN;
+
   if (!repo || !token) {
-    console.error("GITHUB_REPOSITORY and GITHUB_TOKEN must be set");
-    process.exit(1);
+    await writeFallback("GITHUB_REPOSITORY and GITHUB_TOKEN are not set");
+    return;
   }
 
   const url = `https://api.github.com/repos/${repo}/actions/runs?per_page=5`;
@@ -16,23 +30,40 @@ async function main() {
       Accept: "application/vnd.github+json",
     },
   });
+
   if (!res.ok) {
-    console.error(`Failed to fetch workflow runs: ${res.status} ${res.statusText}`);
-    process.exit(1);
+    await writeFallback(
+      `Failed to fetch workflow runs (${res.status} ${res.statusText})`,
+    );
+    return;
   }
+
   const json = await res.json();
-  const runs = json.workflow_runs.map((run) => ({
-    id: run.id,
-    name: run.name,
-    status: run.status,
-    conclusion: run.conclusion,
-    created_at: run.created_at,
-    html_url: run.html_url,
-  }));
-  await writeFile("public/data/actions.json", JSON.stringify(runs, null, 2));
+  const runs = Array.isArray(json.workflow_runs)
+    ? json.workflow_runs.map((run) => ({
+        id: run.id,
+        name: run.name,
+        status: run.status,
+        conclusion: run.conclusion,
+        created_at: run.created_at,
+        html_url: run.html_url,
+      }))
+    : [];
+
+  if (!Array.isArray(json.workflow_runs)) {
+    console.warn(
+      "[actions-status] API response did not contain a workflow_runs array. Writing empty workflow run list.",
+    );
+  }
+
+  await writeRuns(runs);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
+main().catch(async (err) => {
+  console.error("[actions-status] Unexpected error while fetching workflow runs:", err);
+  const message =
+    err instanceof Error
+      ? `Unexpected error: ${err.message}`
+      : `Unexpected non-error rejection: ${JSON.stringify(err)}`;
+  await writeFallback(message);
 });


### PR DESCRIPTION
## Summary
- avoid hard failures in the GitHub Actions status fetch script when required environment variables are absent
- add graceful fallbacks and improved logging so deployments still succeed while surfacing the underlying problem

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caded219308325abeb4b080ac42a0a